### PR TITLE
[建议] 修改底部作者链接

### DIFF
--- a/layout/_partial/social.ejs
+++ b/layout/_partial/social.ejs
@@ -26,7 +26,11 @@
             <% } %>
             <%- current %>
             &nbsp;<i class="iconfont icon-heart"></i>&nbsp;
-            <a target="_blank" href="https://github.com/iJinxin"><%- config.author %></a>
+            <% if (theme.menu.About) { %>
+                <a href="<%= config.root %><%- 'about/' %>"><%- config.author %></a>
+            <% } else { %>
+                <%- config.author %>
+            <% } %>
         </p>
         <p class="theme-info">
             Powered by <a target="_blank" href="https://hexo.io">Hexo</a>  |  Theme -


### PR DESCRIPTION
底部的 author 链接当前为硬编码，是否考虑复用 about 页面